### PR TITLE
Fix leet not working when installed globally

### DIFF
--- a/leet.js
+++ b/leet.js
@@ -96,7 +96,7 @@
         }
     };
 
-    if (/(^|\/)leet\.js$/.test(process.argv[1])) {
+    if (/(^|\/)leet(\.js)?$/.test(process.argv[1])) {
         if (undefined !== process.argv[2]) {
             console.log(leet.output(process.argv[2]));
         } else {


### PR DESCRIPTION
Regex which checks if the script was run by itself wasn't working when you write `leet 'Convert me'`, only when you use the filename: `./leet.js 'Convert me'`. This is now fixed, hopefully letting it be run as a CLI-command.
